### PR TITLE
PGPRO-5646: remove compiler warning (gcc 11.2.0)

### DIFF
--- a/engine.c
+++ b/engine.c
@@ -394,7 +394,17 @@ ptrackCheckpoint(void)
 	 *
 	 * Write both magic and varsion_num at once.
 	 */
-	ptrack_write_chunk(ptrack_tmp_fd, &crc, (char *) &ptrack_map->magic,
+
+	/*
+	 * Previously we read from the field magic, now we read from the beginning
+	 * of the structure PtrackMapHdr. Make sure nothing has changed since then.
+	 */
+	StaticAssertStmt(
+		offsetof(PtrackMapHdr, magic) == 0,
+		"old write format for PtrackMapHdr.magic and PtrackMapHdr.version_num "
+		"is not upward-compatible");
+
+	ptrack_write_chunk(ptrack_tmp_fd, &crc, (char *) ptrack_map,
 					   offsetof(PtrackMapHdr, init_lsn));
 
 	init_lsn = pg_atomic_read_u64(&ptrack_map->init_lsn);


### PR DESCRIPTION
In function ‘ptrack_write_chunk’,
    inlined from ‘ptrackCheckpoint’ at engine.c:397:2:
engine.c:78:13: warning: ‘write’ reading 8 bytes from a region of size 4
[-Wstringop-overread]
   78 |         if (write(fd, chunk, size) != size)
      |             ^~~~~~~~~~~~~~~~~~~~~~
In file included from engine.c:47:
engine.c: In function ‘ptrackCheckpoint’:
engine.h:55:25: note: source object ‘magic’ of size 4
   55 |         char            magic[PTRACK_MAGIC_SIZE];
      |                         ^~~~~
In file included from engine.c:22:
/usr/include/unistd.h:378:16: note: in a call to function ‘write’ declared with
attribute ‘access (read_only, 2, 3)’
  378 | extern ssize_t write (int __fd, const void *__buf, size_t __n) __wur
      |                ^~~~~

In C a pointer to the first field of a structure and a pointer to the structure
itself are always equal.