### PR TITLE
PBCKP-544: Replace macro COMP_CRC32C with wrapper function under windows

### DIFF
--- a/patches/master-ptrack-core.diff
+++ b/patches/master-ptrack-core.diff
@@ -1,8 +1,8 @@
 diff --git a/src/backend/backup/basebackup.c b/src/backend/backup/basebackup.c
-index 715428029b3..81f3218540a 100644
+index 3fb9451643..3d528fd007 100644
 --- a/src/backend/backup/basebackup.c
 +++ b/src/backend/backup/basebackup.c
-@@ -197,6 +197,13 @@ static const struct exclude_list_item excludeFiles[] =
+@@ -199,6 +199,13 @@ static const struct exclude_list_item excludeFiles[] =
  	{"postmaster.pid", false},
  	{"postmaster.opts", false},
  
@@ -16,7 +16,7 @@ index 715428029b3..81f3218540a 100644
  	/* end of list */
  	{NULL, false}
  };
-@@ -212,6 +219,11 @@ static const struct exclude_list_item noChecksumFiles[] = {
+@@ -214,6 +221,11 @@ static const struct exclude_list_item noChecksumFiles[] = {
  	{"pg_filenode.map", false},
  	{"pg_internal.init", true},
  	{"PG_VERSION", false},
@@ -29,7 +29,7 @@ index 715428029b3..81f3218540a 100644
  	{"config_exec_params", true},
  #endif
 diff --git a/src/backend/storage/file/copydir.c b/src/backend/storage/file/copydir.c
-index 658fd95ba95..eee38eba176 100644
+index e04bc3941a..996b5de616 100644
 --- a/src/backend/storage/file/copydir.c
 +++ b/src/backend/storage/file/copydir.c
 @@ -27,6 +27,8 @@
@@ -41,7 +41,7 @@ index 658fd95ba95..eee38eba176 100644
  /*
   * copydir: copy a directory
   *
-@@ -78,6 +80,9 @@ copydir(char *fromdir, char *todir, bool recurse)
+@@ -75,6 +77,9 @@ copydir(const char *fromdir, const char *todir, bool recurse)
  	}
  	FreeDir(xldir);
  
@@ -52,7 +52,7 @@ index 658fd95ba95..eee38eba176 100644
  	 * Be paranoid here and fsync all files to ensure the copy is really done.
  	 * But if fsync is disabled, we're done.
 diff --git a/src/backend/storage/smgr/md.c b/src/backend/storage/smgr/md.c
-index 3deac496eed..07c4ee2ba03 100644
+index 352958e1fe..9dc6bf29f4 100644
 --- a/src/backend/storage/smgr/md.c
 +++ b/src/backend/storage/smgr/md.c
 @@ -87,6 +87,8 @@ typedef struct _MdfdVec
@@ -64,7 +64,7 @@ index 3deac496eed..07c4ee2ba03 100644
  
  /* Populate a file tag describing an md.c segment file. */
  #define INIT_MD_FILETAG(a,xx_rlocator,xx_forknum,xx_segno) \
-@@ -484,6 +486,9 @@ mdextend(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
+@@ -498,6 +500,9 @@ mdextend(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
  		register_dirty_segment(reln, forknum, v);
  
  	Assert(_mdnblocks(reln, forknum, v) <= ((BlockNumber) RELSEG_SIZE));
@@ -74,7 +74,7 @@ index 3deac496eed..07c4ee2ba03 100644
  }
  
  /*
-@@ -773,6 +778,9 @@ mdwrite(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
+@@ -787,6 +792,9 @@ mdwrite(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
  
  	if (!skipFsync && !SmgrIsTemp(reln))
  		register_dirty_segment(reln, forknum, v);
@@ -85,7 +85,7 @@ index 3deac496eed..07c4ee2ba03 100644
  
  /*
 diff --git a/src/backend/storage/sync/sync.c b/src/backend/storage/sync/sync.c
-index 9d6a9e91090..990d0722229 100644
+index 768d1dbfc4..17cbc6bb2a 100644
 --- a/src/backend/storage/sync/sync.c
 +++ b/src/backend/storage/sync/sync.c
 @@ -81,6 +81,8 @@ static MemoryContext pendingOpsCxt; /* context for the above  */
@@ -108,7 +108,7 @@ index 9d6a9e91090..990d0722229 100644
  	sync_in_progress = false;
  }
 diff --git a/src/bin/pg_checksums/pg_checksums.c b/src/bin/pg_checksums/pg_checksums.c
-index 324ccf77834..e82cae5f325 100644
+index aa21007497..96fe58ee3e 100644
 --- a/src/bin/pg_checksums/pg_checksums.c
 +++ b/src/bin/pg_checksums/pg_checksums.c
 @@ -118,6 +118,11 @@ static const struct exclude_list_item skip[] = {
@@ -124,7 +124,7 @@ index 324ccf77834..e82cae5f325 100644
  	{"config_exec_params", true},
  #endif
 diff --git a/src/bin/pg_resetwal/pg_resetwal.c b/src/bin/pg_resetwal/pg_resetwal.c
-index d4772a29650..3318f64359d 100644
+index e7ef2b8bd0..ca7f8cdbc2 100644
 --- a/src/bin/pg_resetwal/pg_resetwal.c
 +++ b/src/bin/pg_resetwal/pg_resetwal.c
 @@ -85,6 +85,7 @@ static void RewriteControlFile(void);
@@ -143,7 +143,7 @@ index d4772a29650..3318f64359d 100644
  	WriteEmptyXLOG();
  
  	printf(_("Write-ahead log reset\n"));
-@@ -1036,6 +1038,41 @@ KillExistingArchiveStatus(void)
+@@ -1029,6 +1031,41 @@ KillExistingArchiveStatus(void)
  		pg_fatal("could not close directory \"%s\": %m", ARCHSTATDIR);
  }
  
@@ -186,7 +186,7 @@ index d4772a29650..3318f64359d 100644
  /*
   * Write an empty XLOG file, containing only the checkpoint record
 diff --git a/src/bin/pg_rewind/filemap.c b/src/bin/pg_rewind/filemap.c
-index 269ed6446e6..6318a8c1f55 100644
+index bd5c598e20..a568156c5f 100644
 --- a/src/bin/pg_rewind/filemap.c
 +++ b/src/bin/pg_rewind/filemap.c
 @@ -157,6 +157,10 @@ static const struct exclude_list_item excludeFiles[] =
@@ -200,21 +200,55 @@ index 269ed6446e6..6318a8c1f55 100644
  	/* end of list */
  	{NULL, false}
  };
-diff --git a/src/include/port/pg_crc32c.h b/src/include/port/pg_crc32c.h
-index d7668651ba8..33994a27f5f 100644
---- a/src/include/port/pg_crc32c.h
-+++ b/src/include/port/pg_crc32c.h
-@@ -69,7 +69,7 @@ extern pg_crc32c pg_comp_crc32c_armv8(pg_crc32c crc, const void *data, size_t le
- #define FIN_CRC32C(crc) ((crc) ^= 0xFFFFFFFF)
+diff --git a/src/include/storage/checksum.h b/src/include/storage/checksum.h
+index 4afd25a0af..c2afee20b5 100644
+--- a/src/include/storage/checksum.h
++++ b/src/include/storage/checksum.h
+@@ -14,6 +14,7 @@
+ #define CHECKSUM_H
  
- extern pg_crc32c pg_comp_crc32c_sb8(pg_crc32c crc, const void *data, size_t len);
--extern pg_crc32c (*pg_comp_crc32c) (pg_crc32c crc, const void *data, size_t len);
-+extern PGDLLIMPORT pg_crc32c (*pg_comp_crc32c) (pg_crc32c crc, const void *data, size_t len);
+ #include "storage/block.h"
++#include "port/pg_crc32c.h"
  
- #ifdef USE_SSE42_CRC32C_WITH_RUNTIME_CHECK
- extern pg_crc32c pg_comp_crc32c_sse42(pg_crc32c crc, const void *data, size_t len);
+ /*
+  * Compute the checksum for a Postgres page.  The page must be aligned on a
+@@ -21,4 +22,18 @@
+  */
+ extern uint16 pg_checksum_page(char *page, BlockNumber blkno);
+ 
++#ifdef WIN32
++/*
++ * Wrapper function for COMP_CRC32C macro. Was added to avoid
++ * FRONTEND macro use for pg_comp_crc32c pointer in windows build.
++ */
++extern void
++comp_crc32c(pg_crc32c *crc, const void *data, size_t len);
++
++#define COMP_CRC32C_COMMON(crc, data, len)	\
++	comp_crc32c(&(crc), data, len)
++#else
++#define COMP_CRC32C_COMMON	COMP_CRC32C
++#endif	/* WIN32 */
++
+ #endif							/* CHECKSUM_H */
+diff --git a/src/include/storage/checksum_impl.h b/src/include/storage/checksum_impl.h
+index 7b157161a2..a69425f6cc 100644
+--- a/src/include/storage/checksum_impl.h
++++ b/src/include/storage/checksum_impl.h
+@@ -213,3 +213,11 @@ pg_checksum_page(char *page, BlockNumber blkno)
+ 	 */
+ 	return (uint16) ((checksum % 65535) + 1);
+ }
++
++#ifdef WIN32
++void
++comp_crc32c(pg_crc32c *crc, const void *data, size_t len)
++{
++	COMP_CRC32C(*crc, data, len);
++}
++#endif
 diff --git a/src/include/storage/copydir.h b/src/include/storage/copydir.h
-index 50a26edeb06..af1602f5154 100644
+index a8be5b21e0..020874f96c 100644
 --- a/src/include/storage/copydir.h
 +++ b/src/include/storage/copydir.h
 @@ -13,6 +13,9 @@
@@ -224,11 +258,11 @@ index 50a26edeb06..af1602f5154 100644
 +typedef void (*copydir_hook_type) (const char *path);
 +extern PGDLLIMPORT copydir_hook_type copydir_hook;
 +
- extern void copydir(char *fromdir, char *todir, bool recurse);
- extern void copy_file(char *fromfile, char *tofile);
+ extern void copydir(const char *fromdir, const char *todir, bool recurse);
+ extern void copy_file(const char *fromfile, const char *tofile);
  
 diff --git a/src/include/storage/md.h b/src/include/storage/md.h
-index 10aa1b0109b..1415675824e 100644
+index 8f32af9ef3..f8b427ceca 100644
 --- a/src/include/storage/md.h
 +++ b/src/include/storage/md.h
 @@ -19,6 +19,13 @@
@@ -246,7 +280,7 @@ index 10aa1b0109b..1415675824e 100644
  extern void mdinit(void);
  extern void mdopen(SMgrRelation reln);
 diff --git a/src/include/storage/sync.h b/src/include/storage/sync.h
-index 049af878dec..7689d49a24e 100644
+index cfbcfa6797..2a432440db 100644
 --- a/src/include/storage/sync.h
 +++ b/src/include/storage/sync.h
 @@ -55,6 +55,9 @@ typedef struct FileTag


### PR DESCRIPTION
to avoid *pg_comp_crc32c import and  influence on other extensions. Use COMP_CRC32C_COMMON for all systems.

Tags: ptrack