### PR TITLE
PBCKP-544 remove crc32c source patch for windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ DATA = ptrack--2.1.sql ptrack--2.0--2.1.sql ptrack--2.1--2.2.sql ptrack--2.2--2.
 
 TAP_TESTS = 1
 
+# This line to link with pgport.lib on Windows compilation
+# with Mkvcbuild.pm on PGv15+
+PG_LIBS_INTERNAL += $(libpq_pgport)
+
 ifdef USE_PGXS
 PG_CONFIG ?= pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/patches/REL_11_STABLE-ptrack-core.diff
+++ b/patches/REL_11_STABLE-ptrack-core.diff
@@ -207,24 +207,6 @@ index 80241455357..50dca7bf6f4 100644
  
  #define IsBootstrapProcessingMode() (Mode == BootstrapProcessing)
  #define IsInitProcessingMode()		(Mode == InitProcessing)
-diff --git a/src/include/port/pg_crc32c.h b/src/include/port/pg_crc32c.h
-index 9a26295c8e8..dc72b27a10d 100644
---- a/src/include/port/pg_crc32c.h
-+++ b/src/include/port/pg_crc32c.h
-@@ -69,8 +69,11 @@ extern pg_crc32c pg_comp_crc32c_armv8(pg_crc32c crc, const void *data, size_t le
- #define FIN_CRC32C(crc) ((crc) ^= 0xFFFFFFFF)
- 
- extern pg_crc32c pg_comp_crc32c_sb8(pg_crc32c crc, const void *data, size_t len);
--extern pg_crc32c (*pg_comp_crc32c) (pg_crc32c crc, const void *data, size_t len);
--
-+extern
-+#ifndef FRONTEND
-+PGDLLIMPORT
-+#endif
-+pg_crc32c (*pg_comp_crc32c) (pg_crc32c crc, const void *data, size_t len);
- #ifdef USE_SSE42_CRC32C_WITH_RUNTIME_CHECK
- extern pg_crc32c pg_comp_crc32c_sse42(pg_crc32c crc, const void *data, size_t len);
- #endif
 diff --git a/src/include/storage/copydir.h b/src/include/storage/copydir.h
 index 4fef3e21072..e55430879c3 100644
 --- a/src/include/storage/copydir.h
@@ -261,3 +243,16 @@ index 0298ed1a2bc..24c684771d0 100644
  extern void mdinit(void);
  extern void mdclose(SMgrRelation reln, ForkNumber forknum);
  extern void mdcreate(SMgrRelation reln, ForkNumber forknum, bool isRedo);
+diff --git a/src/tools/msvc/Mkvcbuild.pm b/src/tools/msvc/Mkvcbuild.pm
+index b52baa90988..74870c048db 100644
+--- a/src/tools/msvc/Mkvcbuild.pm
++++ b/src/tools/msvc/Mkvcbuild.pm
+@@ -33,7 +33,7 @@ my @unlink_on_exit;
+ # Set of variables for modules in contrib/ and src/test/modules/
+ my $contrib_defines = { 'refint' => 'REFINT_VERBOSE' };
+ my @contrib_uselibpq = ('dblink', 'oid2name', 'postgres_fdw', 'vacuumlo');
+-my @contrib_uselibpgport   = ('oid2name', 'pg_standby', 'vacuumlo');
++my @contrib_uselibpgport   = ('oid2name', 'pg_standby', 'vacuumlo', 'ptrack');
+ my @contrib_uselibpgcommon = ('oid2name', 'pg_standby', 'vacuumlo');
+ my $contrib_extralibs      = undef;
+ my $contrib_extraincludes = { 'dblink' => ['src/backend'] };

--- a/patches/REL_12_STABLE-ptrack-core.diff
+++ b/patches/REL_12_STABLE-ptrack-core.diff
@@ -225,24 +225,6 @@ index 61a24c2e3c6..cbd46d0cb02 100644
  
  #define IsBootstrapProcessingMode() (Mode == BootstrapProcessing)
  #define IsInitProcessingMode()		(Mode == InitProcessing)
-diff --git a/src/include/port/pg_crc32c.h b/src/include/port/pg_crc32c.h
-index fbd079d2439..01682035e0b 100644
---- a/src/include/port/pg_crc32c.h
-+++ b/src/include/port/pg_crc32c.h
-@@ -69,8 +69,11 @@ extern pg_crc32c pg_comp_crc32c_armv8(pg_crc32c crc, const void *data, size_t le
- #define FIN_CRC32C(crc) ((crc) ^= 0xFFFFFFFF)
- 
- extern pg_crc32c pg_comp_crc32c_sb8(pg_crc32c crc, const void *data, size_t len);
--extern pg_crc32c (*pg_comp_crc32c) (pg_crc32c crc, const void *data, size_t len);
--
-+extern
-+#ifndef FRONTEND
-+PGDLLIMPORT
-+#endif
-+pg_crc32c (*pg_comp_crc32c) (pg_crc32c crc, const void *data, size_t len);
- #ifdef USE_SSE42_CRC32C_WITH_RUNTIME_CHECK
- extern pg_crc32c pg_comp_crc32c_sse42(pg_crc32c crc, const void *data, size_t len);
- #endif
 diff --git a/src/include/storage/copydir.h b/src/include/storage/copydir.h
 index 525cc6203e1..9481e1c5a88 100644
 --- a/src/include/storage/copydir.h
@@ -289,3 +271,16 @@ index 16428c5f5fb..6b0cd8f8eea 100644
  extern void InitSync(void);
  extern void SyncPreCheckpoint(void);
  extern void SyncPostCheckpoint(void);
+diff --git a/src/tools/msvc/Mkvcbuild.pm b/src/tools/msvc/Mkvcbuild.pm
+index 1bdc33d7168..83b1190775f 100644
+--- a/src/tools/msvc/Mkvcbuild.pm
++++ b/src/tools/msvc/Mkvcbuild.pm
+@@ -33,7 +33,7 @@ my @unlink_on_exit;
+ # Set of variables for modules in contrib/ and src/test/modules/
+ my $contrib_defines = { 'refint' => 'REFINT_VERBOSE' };
+ my @contrib_uselibpq = ('dblink', 'oid2name', 'postgres_fdw', 'vacuumlo');
+-my @contrib_uselibpgport   = ('oid2name', 'pg_standby', 'vacuumlo');
++my @contrib_uselibpgport   = ('oid2name', 'pg_standby', 'vacuumlo', 'ptrack');
+ my @contrib_uselibpgcommon = ('oid2name', 'pg_standby', 'vacuumlo');
+ my $contrib_extralibs      = undef;
+ my $contrib_extraincludes = { 'dblink' => ['src/backend'] };

--- a/patches/REL_13_STABLE-ptrack-core.diff
+++ b/patches/REL_13_STABLE-ptrack-core.diff
@@ -1,9 +1,3 @@
-commit a14ac459d71528c64df00c693e9c71ac70d3ba29
-Author: anastasia <a.lubennikova@postgrespro.ru>
-Date:   Mon Oct 19 14:53:06 2020 +0300
-
-    add ptrack 2.0
-
 diff --git a/src/backend/replication/basebackup.c b/src/backend/replication/basebackup.c
 index 50ae1f16d0..721b926ad2 100644
 --- a/src/backend/replication/basebackup.c
@@ -231,24 +225,6 @@ index 72e3352398..5c2e016501 100644
  
  #define IsBootstrapProcessingMode() (Mode == BootstrapProcessing)
  #define IsInitProcessingMode()		(Mode == InitProcessing)
-diff --git a/src/include/port/pg_crc32c.h b/src/include/port/pg_crc32c.h
-index 3c6f906683..a7355f7ad1 100644
---- a/src/include/port/pg_crc32c.h
-+++ b/src/include/port/pg_crc32c.h
-@@ -69,8 +69,11 @@ extern pg_crc32c pg_comp_crc32c_armv8(pg_crc32c crc, const void *data, size_t le
- #define FIN_CRC32C(crc) ((crc) ^= 0xFFFFFFFF)
- 
- extern pg_crc32c pg_comp_crc32c_sb8(pg_crc32c crc, const void *data, size_t len);
--extern pg_crc32c (*pg_comp_crc32c) (pg_crc32c crc, const void *data, size_t len);
--
-+extern
-+#ifndef FRONTEND
-+PGDLLIMPORT
-+#endif
-+pg_crc32c (*pg_comp_crc32c) (pg_crc32c crc, const void *data, size_t len);
- #ifdef USE_SSE42_CRC32C_WITH_RUNTIME_CHECK
- extern pg_crc32c pg_comp_crc32c_sse42(pg_crc32c crc, const void *data, size_t len);
- #endif
 diff --git a/src/include/storage/copydir.h b/src/include/storage/copydir.h
 index 5d28f59c1d..0d3f04d8af 100644
 --- a/src/include/storage/copydir.h
@@ -295,3 +271,16 @@ index e16ab8e711..88da9686eb 100644
  extern void InitSync(void);
  extern void SyncPreCheckpoint(void);
  extern void SyncPostCheckpoint(void);
+diff --git a/src/tools/msvc/Mkvcbuild.pm b/src/tools/msvc/Mkvcbuild.pm
+index 67b2ea9ee9b..e9a282d5647 100644
+--- a/src/tools/msvc/Mkvcbuild.pm
++++ b/src/tools/msvc/Mkvcbuild.pm
+@@ -34,7 +34,7 @@ my @unlink_on_exit;
+ # Set of variables for modules in contrib/ and src/test/modules/
+ my $contrib_defines = { 'refint' => 'REFINT_VERBOSE' };
+ my @contrib_uselibpq = ('dblink', 'oid2name', 'postgres_fdw', 'vacuumlo');
+-my @contrib_uselibpgport   = ('oid2name', 'pg_standby', 'vacuumlo');
++my @contrib_uselibpgport   = ('oid2name', 'pg_standby', 'vacuumlo', 'ptrack');
+ my @contrib_uselibpgcommon = ('oid2name', 'pg_standby', 'vacuumlo');
+ my $contrib_extralibs      = undef;
+ my $contrib_extraincludes = { 'dblink' => ['src/backend'] };

--- a/patches/REL_14_STABLE-ptrack-core.diff
+++ b/patches/REL_14_STABLE-ptrack-core.diff
@@ -1,9 +1,3 @@
-commit a14ac459d71528c64df00c693e9c71ac70d3ba29
-Author: anastasia <a.lubennikova@postgrespro.ru>
-Date:   Mon Oct 19 14:53:06 2020 +0300
-
-    add ptrack 2.0
-
 diff --git a/src/backend/replication/basebackup.c b/src/backend/replication/basebackup.c
 index 50ae1f16d0..721b926ad2 100644
 --- a/src/backend/replication/basebackup.c
@@ -231,24 +225,6 @@ index 72e3352398..5c2e016501 100644
  
  #define IsBootstrapProcessingMode() (Mode == BootstrapProcessing)
  #define IsInitProcessingMode()		(Mode == InitProcessing)
-diff --git a/src/include/port/pg_crc32c.h b/src/include/port/pg_crc32c.h
-index 3c6f906683..a7355f7ad1 100644
---- a/src/include/port/pg_crc32c.h
-+++ b/src/include/port/pg_crc32c.h
-@@ -69,8 +69,11 @@ extern pg_crc32c pg_comp_crc32c_armv8(pg_crc32c crc, const void *data, size_t le
- #define FIN_CRC32C(crc) ((crc) ^= 0xFFFFFFFF)
- 
- extern pg_crc32c pg_comp_crc32c_sb8(pg_crc32c crc, const void *data, size_t len);
--extern pg_crc32c (*pg_comp_crc32c) (pg_crc32c crc, const void *data, size_t len);
--
-+extern
-+#ifndef FRONTEND
-+PGDLLIMPORT
-+#endif
-+pg_crc32c (*pg_comp_crc32c) (pg_crc32c crc, const void *data, size_t len);
- #ifdef USE_SSE42_CRC32C_WITH_RUNTIME_CHECK
- extern pg_crc32c pg_comp_crc32c_sse42(pg_crc32c crc, const void *data, size_t len);
- #endif
 diff --git a/src/include/storage/copydir.h b/src/include/storage/copydir.h
 index 5d28f59c1d..0d3f04d8af 100644
 --- a/src/include/storage/copydir.h
@@ -295,3 +271,16 @@ index e16ab8e711..88da9686eb 100644
  extern void InitSync(void);
  extern void SyncPreCheckpoint(void);
  extern void SyncPostCheckpoint(void);
+diff --git a/src/tools/msvc/Mkvcbuild.pm b/src/tools/msvc/Mkvcbuild.pm
+index 9b6539fb15d..4b2bcdb6b88 100644
+--- a/src/tools/msvc/Mkvcbuild.pm
++++ b/src/tools/msvc/Mkvcbuild.pm
+@@ -38,7 +38,7 @@ my @unlink_on_exit;
+ my $contrib_defines = { 'refint' => 'REFINT_VERBOSE' };
+ my @contrib_uselibpq =
+   ('dblink', 'oid2name', 'postgres_fdw', 'vacuumlo', 'libpq_pipeline');
+-my @contrib_uselibpgport   = ('libpq_pipeline', 'oid2name', 'vacuumlo');
++my @contrib_uselibpgport   = ('libpq_pipeline', 'oid2name', 'vacuumlo', 'ptrack');
+ my @contrib_uselibpgcommon = ('libpq_pipeline', 'oid2name', 'vacuumlo');
+ my $contrib_extralibs     = { 'libpq_pipeline' => ['ws2_32.lib'] };
+ my $contrib_extraincludes = { 'dblink'         => ['src/backend'] };

--- a/patches/REL_15_STABLE-ptrack-core.diff
+++ b/patches/REL_15_STABLE-ptrack-core.diff
@@ -200,19 +200,6 @@ index 62529310415..b496f54fb06 100644
  	/* end of list */
  	{NULL, false}
  };
-diff --git a/src/include/port/pg_crc32c.h b/src/include/port/pg_crc32c.h
-index d7668651ba8..33994a27f5f 100644
---- a/src/include/port/pg_crc32c.h
-+++ b/src/include/port/pg_crc32c.h
-@@ -69,7 +69,7 @@ extern pg_crc32c pg_comp_crc32c_armv8(pg_crc32c crc, const void *data, size_t le
- #define FIN_CRC32C(crc) ((crc) ^= 0xFFFFFFFF)
- 
- extern pg_crc32c pg_comp_crc32c_sb8(pg_crc32c crc, const void *data, size_t len);
--extern pg_crc32c (*pg_comp_crc32c) (pg_crc32c crc, const void *data, size_t len);
-+extern PGDLLIMPORT pg_crc32c (*pg_comp_crc32c) (pg_crc32c crc, const void *data, size_t len);
- 
- #ifdef USE_SSE42_CRC32C_WITH_RUNTIME_CHECK
- extern pg_crc32c pg_comp_crc32c_sse42(pg_crc32c crc, const void *data, size_t len);
 diff --git a/src/include/storage/copydir.h b/src/include/storage/copydir.h
 index 50a26edeb06..af1602f5154 100644
 --- a/src/include/storage/copydir.h

--- a/patches/master-ptrack-core.diff
+++ b/patches/master-ptrack-core.diff
@@ -200,19 +200,6 @@ index 269ed6446e6..6318a8c1f55 100644
  	/* end of list */
  	{NULL, false}
  };
-diff --git a/src/include/port/pg_crc32c.h b/src/include/port/pg_crc32c.h
-index d7668651ba8..33994a27f5f 100644
---- a/src/include/port/pg_crc32c.h
-+++ b/src/include/port/pg_crc32c.h
-@@ -69,7 +69,7 @@ extern pg_crc32c pg_comp_crc32c_armv8(pg_crc32c crc, const void *data, size_t le
- #define FIN_CRC32C(crc) ((crc) ^= 0xFFFFFFFF)
- 
- extern pg_crc32c pg_comp_crc32c_sb8(pg_crc32c crc, const void *data, size_t len);
--extern pg_crc32c (*pg_comp_crc32c) (pg_crc32c crc, const void *data, size_t len);
-+extern PGDLLIMPORT pg_crc32c (*pg_comp_crc32c) (pg_crc32c crc, const void *data, size_t len);
- 
- #ifdef USE_SSE42_CRC32C_WITH_RUNTIME_CHECK
- extern pg_crc32c pg_comp_crc32c_sse42(pg_crc32c crc, const void *data, size_t len);
 diff --git a/src/include/storage/copydir.h b/src/include/storage/copydir.h
 index 50a26edeb06..af1602f5154 100644
 --- a/src/include/storage/copydir.h
@@ -224,8 +211,8 @@ index 50a26edeb06..af1602f5154 100644
 +typedef void (*copydir_hook_type) (const char *path);
 +extern PGDLLIMPORT copydir_hook_type copydir_hook;
 +
- extern void copydir(char *fromdir, char *todir, bool recurse);
- extern void copy_file(char *fromfile, char *tofile);
+ extern void copydir(const char *fromdir, const char *todir, bool recurse);
+ extern void copy_file(const char *fromfile, const char *tofile);
  
 diff --git a/src/include/storage/md.h b/src/include/storage/md.h
 index 10aa1b0109b..1415675824e 100644


### PR DESCRIPTION
- For Pg <= 14 it is better to link ptrack with pgport.lib by patching Mkvcbuild.pm
- Pg >= 15 reacts on presence of PG_LIBS_INTERNAL += $(libpq_pgport)